### PR TITLE
fix infinite loop due to comparing with string instead of byte

### DIFF
--- a/play_wav.py
+++ b/play_wav.py
@@ -66,7 +66,7 @@ class Sound:
 		data = wf.readframes(chunk)
 
 		# play stream
-		while data != '':
+		while data != b'':
 			stream.write(data)
 			data = wf.readframes(chunk)
 


### PR DESCRIPTION
The interactive CLI remains stuck in an infinite loop after playing an item due to loop condition checking for `''` but data being `b''`.